### PR TITLE
ci(pages): remove earlier bot comments, only keep the latest in PR

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,10 +3,28 @@ name: 'Docusaurus CI/CD'
 on:
   push:
     branches: ['main']
-    paths: ['docs/**', 'blog/**', 'src/**', 'static/**', '**/*.js', 'package.json', 'yarn.lock']
+    paths:
+      [
+        'docs/**',
+        'blog/**',
+        'src/**',
+        'static/**',
+        '**/*.js',
+        'package.json',
+        'yarn.lock',
+      ]
   pull_request:
     branches: ['main']
-    paths: ['docs/**', 'blog/**', 'src/**', 'static/**', '**/*.js', 'package.json', 'yarn.lock']
+    paths:
+      [
+        'docs/**',
+        'blog/**',
+        'src/**',
+        'static/**',
+        '**/*.js',
+        'package.json',
+        'yarn.lock',
+      ]
 
 permissions:
   contents: read
@@ -85,6 +103,44 @@ jobs:
               repo: context.repo.repo,
               body: commentBody
             });
+
+  # Cleanup old comments made by the bot, only keep the most recent
+  cleanup-comments:
+    name: cleanup old bot's comments
+    runs-on: ubuntu-22.04
+    needs: lint-models
+    steps:
+      - name: Remove old bot comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            // Filter comments made by github-actions[bot]
+            const botComments = comments.filter(
+              (comment) => comment.user.login === 'ubunchuu[bot]'
+            );
+
+            // Sort comments by creation date in descending order
+            botComments.sort(
+              (a, b) => new Date(b.created_at) - new Date(a.created_at)
+            );
+
+            // Determine the comments to delete (all except the most recent)
+            const commentsToDelete = botComments.slice(1);
+
+            // Delete the older comments
+            for (const comment of commentsToDelete) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+              });
+            }
 
   deploy-docusaurus:
     if: github.event_name == 'push'


### PR DESCRIPTION
# 🐧 Ubunchuu Contribute Request

## Overview

<!--
Copy this template to the root of your project and update the description to match your project.
Please do not leave this blank!
This PR [adds/removes/fixes/replaces] the [content/feature/bug/etc].
-->

The @ubunchuu-admin performance report's comments are bloating the PR everytime a new commit is pushed.

https://github.com/user-attachments/assets/8dfbd521-7c75-40cb-ae9e-3e09e4551997

## ❓️ What type of PR is this? (check all applicable)

- [ ] 📝 Content - Documentation Update
- [ ] 📝 Content - Blog Update
- [ ] 🎨 Style (UI/UX)
- [ ] 🍕 Feature
- [ ] 🪲 Bug Fix
- [x] 🤖 DevOps
- [ ] 🧑‍💻 Code Refactor

## 📝 Description for my changes

<!--
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

- Added a job to scan the PR and remove ealier bot's comments, only keep the latest one
